### PR TITLE
fix apiserver route port issue.

### DIFF
--- a/hack/deploy-multicluster-controlplane.sh
+++ b/hack/deploy-multicluster-controlplane.sh
@@ -162,7 +162,6 @@ if [ ! -f "$configfile" ] ; then
 dataDirectory: /.ocm
 apiserver:
   externalHostname: ${API_HOST}
-  port: 9443
 etcd:
   mode: embed
   prefix: $HUB_NAME


### PR DESCRIPTION
fix incorrect port for multicluster-controlplane apiserver:

```bash
$ make deploy
...
route.route.openshift.io/multicluster-controlplane configured
Waiting for kubeconfig...
Checking multicluster-controlplane with /tmp/multicluster-controlplane-test2/multicluster-controlplane-test2.kubeconfig ...
Unable to connect to the server: dial tcp 54.83.160.13:9443: i/o timeout
Checking multicluster-controlplane with /tmp/multicluster-controlplane-test2/multicluster-controlplane-test2.kubeconfig ...
Unable to connect to the server: dial tcp 52.22.29.199:9443: i/o timeout
...
``` 