### PR TITLE
Set ETCD_SNAPSHOT_COUNT as 5000 and update-frequency as 60s

### DIFF
--- a/charts/multicluster-controlplane/templates/deployment.yaml
+++ b/charts/multicluster-controlplane/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         {{- if eq .Values.enableDelegatingAuthentication true }}
         - "--delegating-authentication"
         {{- end }}
+        env:
+        - name: ETCD_SNAPSHOT_COUNT
+          value: "{{ .Values.etcd.snapshotCount }}"
         resources:
         {{- toYaml .Values.resources | nindent 10 }}
         securityContext:

--- a/charts/multicluster-controlplane/values.yaml
+++ b/charts/multicluster-controlplane/values.yaml
@@ -24,6 +24,7 @@ apiserver:
   cakey: ""
 etcd:
   mode: "embed"
+  snapshotCount: 5000
   servers: []
   ca: ""
   cert: "" 

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -70,7 +70,7 @@ func NewAgent() *cobra.Command {
 	flags.UintVar(
 		&agentOptions.Frequency,
 		"update-frequency",
-		10,
+		60,
 		"The status update frequency (in seconds) of a mutation policy",
 	)
 

--- a/hack/deploy/etcd/statefulset.yaml
+++ b/hack/deploy/etcd/statefulset.yaml
@@ -33,6 +33,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: ETCD_SNAPSHOT_COUNT
+          value: "5000"
         command:
           - "/bin/sh"
           - "-ecx"


### PR DESCRIPTION
1.  Set ETCD_SNAPSHOT_COUNT as 5000 to reduce the memory consumption - https://etcd.io/docs/v3.5/tuning/#snapshots. the default value is 100000. After set as 5000, the memory consumption can reduce 600M in 15 managed clusters and 41 policies environment.
2. it is too frequency to check the compliance status in 10 seconds.